### PR TITLE
Updates example app and server initialisation examples in doc comments to use serve() instead of deprecated listenAndServe()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
     - name: Check formatting
       run: make format-check
 
+    # This is a sanity check to ensure that
+    # there haven't been any breaking changes
+    # to server initialisation in Deno.
+    - name: Compile example app
+      run: make compile-example
+
     - name: Unit tests
       run: make test
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ typings/
 .next
 
 types
+server.out

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ lint:
 test:
 	${HOME}/.deno/bin/deno test reno example
 
+compile-example:
+	${HOME}/.deno/bin/deno compile -o server.out example/server.ts
+
 install-types:
 	mkdir -p types
 	${HOME}/.deno/bin/deno types > types/deno.d.ts

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Reno logo](https://raw.githubusercontent.com/reno-router/reno/master/logo/reno-500.png)
 
-[![Build status](https://github.com/reno-router/reno/workflows/CI/badge.svg)](https://github.com/reno-router/reno/actions) [![Deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/reno@v2.0.18/reno/mod.ts) [![Published on Nest.land](https://nest.land/badge.svg)](https://nest.land/package/reno)
+[![Build status](https://github.com/reno-router/reno/workflows/CI/badge.svg)](https://github.com/reno-router/reno/actions) [![Deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/reno@v2.0.19/reno/mod.ts) [![Published on Nest.land](https://nest.land/badge.svg)](https://nest.land/package/reno)
 
 Reno is a thin routing library designed to sit on top of [Deno](https://deno.land/)'s [standard HTTP module](https://deno.land/std/http).
 
@@ -18,20 +18,22 @@ Reno is a thin routing library designed to sit on top of [Deno](https://deno.lan
 ## Overview
 
 ```tsx
-import { listenAndServe } from "https://deno.land/std@0.118.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.118.0/http/server.ts";
 
 import {
   AugmentedRequest,
   createRouteMap,
   createRouter,
   jsonResponse,
-  streamResponse,
   MissingRouteError,
-} from "https://deno.land/x/reno@v2.0.18/reno/mod.ts";
+  streamResponse,
+} from "https://deno.land/x/reno@v2.0.19/reno/mod.ts";
 
 /* Alternatively, you can import Reno from nest.land:
  * import { ... } from "https://x.nest.land/reno@2.0.18/reno/mod.ts";
  */
+
+const PORT = 8000;
 
 function createErrorResponse(status: number, { message }: Error) {
   return new Response(message, {
@@ -40,7 +42,7 @@ function createErrorResponse(status: number, { message }: Error) {
 }
 
 export const routes = createRouteMap([
-  ["/home", () => new Response("Hello world!")],
+  ["/", () => new Response("Hello world!")],
 
   // Supports RegExp routes for further granularity
   [/^\/api\/swanson\/?([0-9]?)$/, async (req: AugmentedRequest) => {
@@ -54,9 +56,10 @@ export const routes = createRouteMap([
   }],
 
   // Supports Reader for streaming responses in chunks
-  ["/streamed-response", () => streamResponse(
-    new ReactReader(<App />),
-  )],
+  ["/streamed-response", () =>
+    streamResponse(
+      new ReactReader(<App />),
+    )],
 ]);
 
 const notFound = (e: MissingRouteError) => createErrorResponse(404, e);
@@ -67,16 +70,18 @@ const mapToErrorResponse = (e: Error) =>
 
 const router = createRouter(routes);
 
-console.log("Listening for requests...");
+console.log(`Listening for requests on port ${PORT}...`);
 
-await listenAndServe(
-  ":8001",
-  async req => {
+await serve(
+  async (req) => {
     try {
       return await router(req);
     } catch (e) {
       return mapToErrorResponse(e);
     }
+  },
+  {
+    port: PORT,
   },
 );
 ```
@@ -88,7 +93,7 @@ await listenAndServe(
 This, along with request handlers being [pure functions](https://en.wikipedia.org/wiki/Pure_function), makes unit testing Reno services a breeze:
 
 ```ts
-import { jsonResponse, assertResponsesAreEqual } from "https://deno.land/x/reno@v2.0.18/reno/mod.ts";
+import { jsonResponse, assertResponsesAreEqual } from "https://deno.land/x/reno@v2.0.19/reno/mod.ts";
 import { createRonSwansonQuoteHandler } from "./routes.ts";
 
 const createFetchStub = (response: string[]) =>
@@ -171,7 +176,7 @@ import {
   AugmentedRequest,
   RouteHandler,
   createRouteMap
-} from "https://deno.land/x/reno@v2.0.18/reno/mod.ts";
+} from "https://deno.land/x/reno@v2.0.19/reno/mod.ts";
 
 import isValidAPIKey from "./api_keys.ts";
 
@@ -230,11 +235,11 @@ Deno.test("/ should return the expected response", async () => {
 
 ## Example Apps
 
-As well as the [example app found in this repo](https://github.com/reno-router/reno/tree/v2.0.18/example), which is targetted by the end-to-end test suite, there is a [standalone repository for a blog microservice](https://github.com/reno-router/blog-microservice) built with Deno, Reno, PostgreSQL, and Docker.
+As well as the [example app found in this repo](https://github.com/reno-router/reno/tree/v2.0.19/example), which is targetted by the end-to-end test suite, there is a [standalone repository for a blog microservice](https://github.com/reno-router/blog-microservice) built with Deno, Reno, PostgreSQL, and Docker.
 
 ## API Documentation
 
-Consult [Reno's entry on the Deno Doc website](https://doc.deno.land/https/deno.land/x/reno@v2.0.18/reno/mod.ts) for comprehensive documentation on Reno's API.
+Consult [Reno's entry on the Deno Doc website](https://doc.deno.land/https/deno.land/x/reno@v2.0.19/reno/mod.ts) for comprehensive documentation on Reno's API.
 
 ## Local Development
 

--- a/README.template.md
+++ b/README.template.md
@@ -18,20 +18,22 @@ Reno is a thin routing library designed to sit on top of [Deno](https://deno.lan
 ## Overview
 
 ```tsx
-import { listenAndServe } from "https://deno.land/std@0.118.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.118.0/http/server.ts";
 
 import {
   AugmentedRequest,
   createRouteMap,
   createRouter,
   jsonResponse,
-  streamResponse,
   MissingRouteError,
+  streamResponse,
 } from "https://deno.land/x/reno@v{{version}}/reno/mod.ts";
 
 /* Alternatively, you can import Reno from nest.land:
- * import { ... } from "https://x.nest.land/reno@{{version}}/reno/mod.ts";
+ * import { ... } from "https://x.nest.land/reno@2.0.18/reno/mod.ts";
  */
+
+const PORT = 8000;
 
 function createErrorResponse(status: number, { message }: Error) {
   return new Response(message, {
@@ -40,7 +42,7 @@ function createErrorResponse(status: number, { message }: Error) {
 }
 
 export const routes = createRouteMap([
-  ["/home", () => new Response("Hello world!")],
+  ["/", () => new Response("Hello world!")],
 
   // Supports RegExp routes for further granularity
   [/^\/api\/swanson\/?([0-9]?)$/, async (req: AugmentedRequest) => {
@@ -54,9 +56,10 @@ export const routes = createRouteMap([
   }],
 
   // Supports Reader for streaming responses in chunks
-  ["/streamed-response", () => streamResponse(
-    new ReactReader(<App />),
-  )],
+  ["/streamed-response", () =>
+    streamResponse(
+      new ReactReader(<App />),
+    )],
 ]);
 
 const notFound = (e: MissingRouteError) => createErrorResponse(404, e);
@@ -67,16 +70,18 @@ const mapToErrorResponse = (e: Error) =>
 
 const router = createRouter(routes);
 
-console.log("Listening for requests...");
+console.log(`Listening for requests on port ${PORT}...`);
 
-await listenAndServe(
-  ":8001",
-  async req => {
+await serve(
+  async (req) => {
     try {
       return await router(req);
     } catch (e) {
       return mapToErrorResponse(e);
     }
+  },
+  {
+    port: PORT,
   },
 );
 ```

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
   "name": "reno",
   "description": "A thin routing library designed to sit on top of Deno's standard HTTP module",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "repository": "https://github.com/reno-router/reno/",
   "stable": true,
   "files": [

--- a/example/server.ts
+++ b/example/server.ts
@@ -1,9 +1,11 @@
-import { listenAndServe } from "https://deno.land/std@0.118.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.118.0/http/server.ts";
 
 import app from "./app.ts";
 
-const BINDING = ":8000";
+const PORT = 8000;
 
-console.log(`Listening for requests on ${BINDING}...`);
+console.log(`Listening for requests on ${PORT}...`);
 
-await listenAndServe(BINDING, app);
+await serve(app, {
+  port: PORT,
+});

--- a/reno/router.ts
+++ b/reno/router.ts
@@ -168,24 +168,26 @@ export function routerCreator(
  * Deno's HTTP server receives a request:
  *
  * ```ts
- * import { listenAndServe } from "https://deno.land/std@0.118.0/http/server.ts";
+ * import { serve } from "https://deno.land/std@0.118.0/http/server.ts";
  * import { createRouter } from "https://deno.land/x/reno@<VERSION>/reno/mod.ts";
  * import { routes } from "./routes.ts";
  *
- * const BINDING = ":8000";
+ * const PORT = ":8000";
  *
  * const router = createRouter(routes);
  *
- * console.log(`Listening for requests on ${BINDING}...`);
+ * console.log(`Listening for requests on ${PORT}...`);
  *
- * await listenAndServe(
- *   BINDING,
+ * await serve(
  *   async req => {
  *     try {
  *       return await router(req);
  *     } catch (e) {
  *       return mapToErrorResponse(e);
  *     }
+ *   },
+ *   {
+ *     port: PORT,
  *   },
  * );
  * ```


### PR DESCRIPTION
Also compiles the example server, via its entry point, as part of the CI pipeline to ensure that any future breaking changes around Deno's HTTP server APIs are captured.